### PR TITLE
Define input for single point cloud in .mat file

### DIFF
--- a/src/tools/define_input.m
+++ b/src/tools/define_input.m
@@ -72,9 +72,9 @@ inputs(nt).PatchDiam1 = 0;
 
 %% Estimate the PatchDiam and BallRad parameters
 for i = 1:nt
+  % Select point cloud
+  P = matobj.(names{i});
   if nt > 1
-    % Select point cloud
-    P = matobj.(names{i});
     inputs(i) = Inputs;
     inputs(i).name = names{i};
     inputs(i).tree = i;


### PR DESCRIPTION
Previously, the variable "P" was not defined for lines 89 and beyond if the .mat file with point clouds to be processed only contained a single point cloud. By moving the definition of P outside the nt > 1 condition, P is defined in the case of only one point cloud, and nothing is different if nt > 1.